### PR TITLE
Add functionality to auto convert an associated error to message

### DIFF
--- a/journalhook_test.go
+++ b/journalhook_test.go
@@ -1,6 +1,7 @@
 package journalhook
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,4 +51,45 @@ func TestCheckSmallMessage(t *testing.T) {
 	require.True(t, strings.Contains(string(out), "PRIORITY\" : \"6"))
 	require.True(t, strings.Contains(string(out), "STRUCT\" : \"{field1 2 map[3:0.4 5:6.7]}"))
 	require.True(t, strings.Contains(string(out), "BYTES\" : [ 10, 222, 173, 190, 239 ]"))
+}
+
+func TestCheckErrMessage(t *testing.T) {
+	log := logrus.New()
+	hook, err := NewJournalHookWithErrToMsg()
+	require.NoError(t, err)
+	log.Hooks.Add(hook)
+
+	err = errors.New("something something dark side")
+
+	log.WithField("test_id", uniqueSmallMessageID).WithError(err).Error()
+
+	time.Sleep(time.Second * 5)
+
+	out, err := exec.Command("sh", "-c", fmt.Sprintf("journalctl 'TEST_ID=%s' -o json", uniqueSmallMessageID)).Output()
+	fmt.Println(string(out))
+
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(out), "MESSAGE\" : \"something something dark side"))
+	require.True(t, strings.Contains(string(out), "PRIORITY\" : \"3"))
+}
+
+func TestCheckErrMessageWithMessage(t *testing.T) {
+	log := logrus.New()
+	hook, err := NewJournalHookWithErrToMsg()
+	require.NoError(t, err)
+	log.Hooks.Add(hook)
+
+	err = errors.New("something something dark side")
+
+	log.WithField("test_id", uniqueSmallMessageID).WithError(err).Error("are we there yet")
+
+	time.Sleep(time.Second * 5)
+
+	out, err := exec.Command("sh", "-c", fmt.Sprintf("journalctl 'TEST_ID=%s' -o json", uniqueSmallMessageID)).Output()
+	fmt.Println(string(out))
+
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(out), "ERROR\" : \"something something dark side"))
+	require.True(t, strings.Contains(string(out), "MESSAGE\" : \"are we there yet"))
+	require.True(t, strings.Contains(string(out), "PRIORITY\" : \"3"))
 }


### PR DESCRIPTION
Default journalctl output will only show the contents of the `MESSAGE` field. If the message is empty but the entry has an associated error, we may replace the message with the contents of the error so that it is shown in the journalctl output by default.

This makes it possible to use `log.WithError(err).Error()` without providing an additional error message.

## Example

```go
journalHook, err := journalhook.NewJournalHookWithErrToMsg()

log.AddHook(journalHook)

err = fmt.Errorf("asdads: %s", "omg")

log.WithError(err).Error()
log.WithError(err).Error("Asdad")
```

Results in the following in the log:

~~~
$ journalctl _COMM=test --output json -n 2 | jq '{ERROR, MESSAGE, PRIORITY}'
{
  "ERROR": null,
  "MESSAGE": "asdads: omg",
  "PRIORITY": "3"
}
{
  "ERROR": "asdads: omg",
  "MESSAGE": "Asdad",
  "PRIORITY": "3"
}
~~~